### PR TITLE
Remove noop package "babel" from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "homepage": "https://github.com/i18next/i18next-intervalPlural-postProcessor",
   "bugs": "https://github.com/i18next/i18next-intervalPlural-postProcessor/issues",
   "dependencies": {
-    "babel": "^6.5.2",
     "babel-cli": "^6.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
   ],
   "homepage": "https://github.com/i18next/i18next-intervalPlural-postProcessor",
   "bugs": "https://github.com/i18next/i18next-intervalPlural-postProcessor/issues",
-  "dependencies": {
-    "babel-cli": "^6.6.4"
-  },
   "devDependencies": {
     "babel-cli": "6.6.5",
     "babel-core": "6.4.5",


### PR DESCRIPTION
> `npm WARN deprecated babel@6.5.2: Babel's CLI commands have been moved from the babel package to the babel-cli package`

This is causing some level of broken-ness in any project depending on this package.
