### PR TITLE
fix: update typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,11 +6,11 @@ interface IntervalPluralOptions {
 	intervalSuffix: string;
 }
 
-const intervalPlural: PostProcessorModule & {
+declare const intervalPlural: PostProcessorModule & {
 	name: 'interval';
 	type: 'postProcessor';
 	options: IntervalPluralOptions;
 	setOptions: (options: Partial<IntervalPluralOptions>) => void;
 };
 
-export default intervalPlural;
+export = intervalPlural;


### PR DESCRIPTION
Updates typescript definition to use `declare` (addresses #219) and `export =` instead of `export default` (more accurate to source)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- ~~[ ] tests are included~~ N/A
- ~~[ ] documentation is changed or added~~ N/A