### PR TITLE
fix: fixed an issue with variable replacement #221

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default {
 
   options: {
     intervalSeparator: ';',
-    intervalRegex: /\((\S*)\).*{((.|\n)*)}/,
+    intervalRegex: /\((\S*)\)((.|\n)*)/,
     intervalSuffix: '_interval'
   },
 
@@ -32,12 +32,12 @@ export default {
 
   process(value, key, options, translator) {
     const p = value.split(this.options.intervalSeparator);
+    console.log(value, p);
 
     let found;
     p.forEach((iv) => {
       if (found) return;
       let match = this.options.intervalRegex.exec(iv);
-
       if (match && intervalMatches(match[1], options.count || 0)) {
         found = match[2];
       }

--- a/test/interval.spec.js
+++ b/test/interval.spec.js
@@ -1,6 +1,6 @@
+import { expect } from 'chai';
 import i18next from 'i18next';
 import intervalPostProcessor from '../src/';
-import { expect } from 'chai';
 
 describe('interval plural', () => {
   before(() => {
@@ -17,31 +17,37 @@ describe('interval plural', () => {
       i18next.addResourceBundle('en', 'test1', {
         key1: '{{count}} item',
         key1_plural: '{{count}} items',
-        key1_interval: '(1){one item};(2-7){a few items};(7-inf){a lot of items};',
+        key1_interval: '(1)one item;(2-7)a few items;(7-inf)a lot of items;',
         key2: '{{count}} item',
         key2_plural: '{{count}} items',
-        key2_interval: '(1){one item};(2-7){a few items};'
+        key2_interval: '(1)one item;(2-7)a few items;'
       });
       i18next.addResourceBundle('en', 'test2', {
         key3: '{{count}} item',
         key3_plural: '{{count}} items',
-        key3_interval: '(1){one item};(2-7){a few items};(7-inf){a lot of items};',
+        key3_interval: '(1)one item;(2-7)a few items;(7-inf)a lot of items;',
         key4: '{{count}} item',
         key4_plural: '{{count}} items',
-        key4_interval: '(1){one item};(2-7){a few items};'
+        key4_interval: '(1)one item;(2-7)a few items;'
       });
       i18next.addResourceBundle('en', 'test3', {
         key3: '{{count}} item',
         key3_plural: '{{count}} items',
-        key3_interval: '(1) {one item}; (2-7) {a few items}; (7-inf) {a lot of items};',
+        key3_interval: '(1)one item; (2-7)a few items; (7-inf)a lot of items;',
         key4: '{{count}} item',
         key4_plural: '{{count}} items',
-        key4_interval: '(1){one item}; (2-7){a few items}; '
+        key4_interval: '(1)one item; (2-7)a few items; '
       });
       i18next.addResourceBundle('en', 'test4', {
         LIKE_COUNT: '{{count}} person\nlikes this',
         LIKE_COUNT_plura: '{{count}} people\nlike this',
-        LIKE_COUNT_interval: "(0){No one\nlikes this};"
+        LIKE_COUNT_interval: "(0)No one\nlikes this;"
+      });
+      i18next.addResourceBundle("en", "test5", {
+        key5: "{{count}} item",
+        key5_plural: "{{count}} items",
+        key5_interval:
+          "(0)no items; (1){{name}}; (2-inf)a lot of items;",
       });
       i18next.setDefaultNamespace('test1');
     });
@@ -67,7 +73,11 @@ describe('interval plural', () => {
       {args: ['key4_interval', { ns: 'test3', postProcess: 'interval', count: 3}], expected: 'a few items'},
       {args: ['key4_interval', { ns: 'test3', postProcess: 'interval', count: 100}], expected: '100 items'},
 
-      {args: ['LIKE_COUNT_interval', { ns: 'test4', postProcess: 'interval', count: 0}], expected: 'No one\nlikes this'}
+      {args: ['LIKE_COUNT_interval', { ns: 'test4', postProcess: 'interval', count: 0}], expected: 'No one\nlikes this'},
+      
+      {args: ['key5_interval', { ns: 'test5', postProcess: 'interval', count: 0}], expected: 'no items'},
+      {args: ['key5_interval', { ns: 'test5', postProcess: 'interval', count: 1, name: 'TEST'}], expected: 'TEST'},
+      {args: ['key5_interval', { ns: 'test5', postProcess: 'interval', count: 3}], expected: 'a lot of items'},
     ];
 
     tests.forEach((test) => {


### PR DESCRIPTION
This proposal is a breaking change but it fixes an issue where the curly brackets in the regex matcher conflict with i18next variable replacement. This change proposes to completely remove them having the translation right after the round brackets for count.

#### Checklist

- [x ] only relevant code is changed (make a diff before you submit the PR)
- [x ] run tests `npm run test`
- [x ] tests are included
- [ ] documentation is changed or added